### PR TITLE
breakin: Update fan/temp results handling

### DIFF
--- a/breakin.c
+++ b/breakin.c
@@ -506,17 +506,15 @@ int get_ipmi_sensors() {
 				}
 				/* value */
 				else if (i == 1) {
-					if (sscanf(chunk, "%d %*s", &value) >= 1) {
-						found_value = 1;
-					}
+					found_value = !!sscanf(chunk, "%d ", &value);
 				}
-				i ++;
+				i++;
 			}	
 			if (found_label && found_value) {
 				if (temp_qty < MAX_TEMPS) {
 					snprintf(temp_data[temp_qty].name, sizeof(temp_data[temp_qty].name), "%s", label);
 					temp_data[temp_qty].value = value;
-					temp_qty ++;
+					temp_qty++;
 				}
 			}
 		}
@@ -532,21 +530,20 @@ int get_ipmi_sensors() {
 				chunk = strsep(&string, "|");
 				/* label */
 				if (i == 0) {
-					snprintf(label, sizeof(label), "%s", trim(chunk));
+					snprintf(label, sizeof(label), "%s", trim(chunk) + 3);
 					found_label = 1;
 				}
 				/* value */
 				else if (i == 1) {
-					sscanf(chunk, "%d %*s", &value);	
-					found_value = 1;
+					found_value = !!sscanf(chunk, "%d ", &value);
 				}
-				i ++;
+				i++;
 			}	
 			if (found_label && found_value) {
-				if (temp_qty < MAX_FANS) {
+				if (fan_qty < MAX_FANS) {
 					snprintf(fan_data[fan_qty].name, sizeof(fan_data[fan_qty].name), "%s", label);
 					fan_data[fan_qty].value = value;
-					fan_qty ++;
+					fan_qty++;
 				}
 			}
 		}
@@ -1605,9 +1602,7 @@ int main(int argc, char **argv) {
 	}
 
 	find_burnin_tests();
-
 	get_ipmi_sensors(); 
-
 	setup_screen();			/* initalize the ncurses screen */
 
 	/* these functions do not need to be run multiple times */

--- a/scripts/ipmi.sh
+++ b/scripts/ipmi.sh
@@ -8,10 +8,10 @@ then
 fi
 
 get_ipmi() {
-	ipmitool sdr type Temperature | cut -d"|" -f1,5 | sed s/Temperature// > /tmp/ipmi_temp.log.tmp 2> /dev/null
+	ipmitool sdr type Temperature 2>/dev/null | cut -d"|" -f1,5 | sed s/Temperature// > /tmp/ipmi_temp.log.tmp
 	mv /tmp/ipmi_temp.log.tmp /tmp/ipmi_temp.log
 
-	ipmitool sdr type Fan | cut -d"|" -f1,5 | sed s/Fan// > /tmp/ipmi_fan.log.tmp 2> /dev/null
+	ipmitool sdr type Fan 2>/dev/null | cut -d"|" -f1,5 | sed s/Fan// > /tmp/ipmi_fan.log.tmp
 	mv /tmp/ipmi_fan.log.tmp /tmp/ipmi_fan.log
 }
 

--- a/scripts/startup.sh
+++ b/scripts/startup.sh
@@ -38,5 +38,5 @@ echo "Getting IPMI values"
 ${DESTDIR}/etc/breakin/ipmi.sh
 
 echo "Starting IPMI server process"
-${DESTDIR}/etc/breakin/ipmi.sh 30 &
+${DESTDIR}/etc/breakin/ipmi.sh 10 &
 exec ${DESTDIR}/bin/breakin ${ARGS}

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 killall -9 @DESTDIR@/bin/hpl
+killall -9 @DESTDIR@/etc/breakin/ipmi.sh
 sync
 echo "Breakin was stopped"


### PR DESCRIPTION
* s/temp_/fan_/ [typo]
* simplify sscanf() call
* remove redundant 'FAN' prefix